### PR TITLE
handle 422 error due to SAML link errors

### DIFF
--- a/add_users.py
+++ b/add_users.py
@@ -65,7 +65,13 @@ def github_api_get_request(path):
 def github_api_put_request(path):
     r = requests.put("https://api.github.com/" + path, auth=(accessKey, ''))
 
-    if r.status_code != 200:
+    if r.status_code == 422:
+        print "INFO: Request to " + path + " resulted with 422, which can be ignored since it has to do with SAML"   
+        return {
+          "state" : "no SSO",
+          "role"  : "member"
+        }
+    elif r.status_code != 200:
         print "ERROR: Request to " + path + " resulted with " + str(r.status_code)
         print "ERROR: Internal error when updating team membership."
         quit()


### PR DESCRIPTION
Our organisation has SSO / SAML installed.

Users which have not yet linked their account to the right SSO identifier, will cause an error when adding them to a team.
This will stop the program.

I've added an exception for error 422, so the rest of the organisation are still added to the team.
This is only an issue when SSO is enabled for an organisation.

Feel free to accept or ignore this PR. 